### PR TITLE
modify: error 메세지 출력시, ft_print_err 사용하도록 수정

### DIFF
--- a/srcs/1_parsing/ft_count_token.c
+++ b/srcs/1_parsing/ft_count_token.c
@@ -6,7 +6,7 @@
 /*   By: tnam <tnam@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/26 15:28:40 by tnam              #+#    #+#             */
-/*   Updated: 2023/04/28 20:25:02 by tnam             ###   ########.fr       */
+/*   Updated: 2023/05/25 16:27:17 by tnam             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,10 +64,8 @@ static int	ft_quote_process(t_parse *parse)
 		&& parse->line[parse->line_i] != end_quote)
 		parse->line_i++;
 	if (parse->line[parse->line_i] == '\0')
-	{
-		printf("Error\nQuote %c is not closed.\n", end_quote);
-		return (FAILURE);
-	}
+		return (ft_error("Quote %c is not closed.\n", end_quote),
+			FAILURE);
 	return (SUCCESS);
 }
 

--- a/srcs/3_exec/ft_exec_cmd.c
+++ b/srcs/3_exec/ft_exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: tnam <tnam@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/22 20:18:43 by tnam              #+#    #+#             */
-/*   Updated: 2023/05/25 13:36:45 by tnam             ###   ########.fr       */
+/*   Updated: 2023/05/25 16:29:42 by tnam             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,7 +107,7 @@ void	ft_exec_cmd(t_info *info, t_parse *parse,
 	if (ft_is_builtin_child(exec_info) == FALSE
 		&& ft_find_cmd(exec, exec_info) == FAILURE)
 	{
-		printf("%s: command not found\n", exec_info->cmd[0]);
+		ft_printf_err("%s: command not found\n", exec_info->cmd[0]);
 		ft_free_all(parse, exec);
 		exit(127);
 	}

--- a/srcs/utils/ft_error.c
+++ b/srcs/utils/ft_error.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_error.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jeekpark <jeekpark@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tnam <tnam@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/18 18:41:42 by jeekpark          #+#    #+#             */
-/*   Updated: 2023/04/18 18:43:27 by jeekpark         ###   ########.fr       */
+/*   Updated: 2023/05/25 16:23:15 by tnam             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,6 @@
 
 int	ft_error(char *msg, int error_code)
 {
-	printf("Error\n%s\n", msg);
+	ft_printf_err("Error\n%s\n", msg);
 	return (error_code);
 }


### PR DESCRIPTION
- error 메세지 출력을 위해 ft_error() 호출시, ft_print_err() 사용하도록 수정.

Related to: #3